### PR TITLE
remove duplicated env parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,17 @@ matrix:
       env:
       - CUDA=8.0.61-1
       - CUDA_SHORT=8.0
-      - CUDA_APT=8-0
       - UBUNTU_VERSION=ubuntu1604
       dist: xenial
     - name: CUDA 9
       env:
       - CUDA=9.2.148-1
       - CUDA_SHORT=9.2
-      - CUDA_APT=9-2
       - UBUNTU_VERSION=ubuntu1604
       dist: xenial
     - name: CUDA 10
       env:
       - CUDA=10.1.105-1
-      - CUDA_APT=10-1
       - CUDA_SHORT=10.1
       - UBUNTU_VERSION=ubuntu1804
       dist: bionic
@@ -36,7 +33,7 @@ before_install:
   - wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/7fa2af80.pub
   - sudo apt-key add 7fa2af80.pub
   - sudo apt update -qq
-  - sudo apt install -y cuda-core-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} cuda-cufft-dev-${CUDA_APT}
+  - sudo apt install -y cuda-core-${CUDA_SHORT/./-} cuda-cudart-dev-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
   - sudo apt clean
   - CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
   - LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}


### PR DESCRIPTION
the `CUDA_APT` is not needed since it is the same as `CUDA_SHORT` just with replaced "." by "-"